### PR TITLE
Update telegram.md: через epm play устанавливается официальная бинарная сборка

### DIFF
--- a/docs/apps/telegram.md
+++ b/docs/apps/telegram.md
@@ -5,7 +5,7 @@ aggregation:
   epm:
     play:
       id: telegram
-      build: unofficial
+      build: official
 appstream:
   id: org.telegram.desktop
   name: Telegram


### PR DESCRIPTION
Через epm play устанавливается официальная бинарная сборка, а в описании почему-то указано unofficial.